### PR TITLE
Fix hidesBottomBarWhenPushed usage

### DIFF
--- a/TabBarSolution/MainTabBar.swift
+++ b/TabBarSolution/MainTabBar.swift
@@ -18,6 +18,10 @@ class MainTabBar: UITabBar {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if self.isHidden {
+            return super.hitTest(point, with: event)
+        }
+        
         let from = point
         let to = middleButton.center
 


### PR DESCRIPTION
When you use `hidesBottomBarWhenPushed` and then push a new controller onto the stack, the area of the middle button was still tappable. This fixes that.